### PR TITLE
Server side exception re thrown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage.xml
 build
 .idea
 dist
+__pycache__

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='visual_regression_tracker',
-    version='4.1.0',
+    version='4.2.0',
     description='Open source, self hosted solution for visual testing '
                 'and managing results of visual testing.',
     long_description=open('README.md').read(),

--- a/tests/test_visualRegressionTracker.py
+++ b/tests/test_visualRegressionTracker.py
@@ -5,7 +5,7 @@ import pytest
 from visual_regression_tracker import \
     Config, VisualRegressionTracker, \
     TestRun, TestRunResult, TestRunStatus, \
-    ServerError, TestFailed, VisualRegressionTrackerError
+    ServerError, TestRunError, VisualRegressionTrackerError
 from visual_regression_tracker.types import \
     _to_dict
 from visual_regression_tracker.visualRegressionTracker import \
@@ -99,7 +99,7 @@ def test__track__should_raise_exception(test_run_result, expected_error, vrt, mo
     vrt.config.enableSoftAssert = False
     vrt._submitTestResult = mocker.Mock(return_value=test_run_result)
 
-    with pytest.raises(TestFailed, match=expected_error):
+    with pytest.raises(TestRunError, match=expected_error):
         vrt.track(TestRun())
 
 

--- a/visual_regression_tracker/__init__.py
+++ b/visual_regression_tracker/__init__.py
@@ -20,11 +20,11 @@ Basic usage:
 """
 
 from .types import Config, Build, TestRun, TestRunResult, TestRunStatus
-from .exceptions import VisualRegressionTrackerError, ServerError, TestFailed
+from .exceptions import VisualRegressionTrackerError, ServerError, TestRunError
 from .visualRegressionTracker import VisualRegressionTracker
 
 __all__ = [
     'Config', 'Build', 'TestRun', 'TestRunResult', 'TestRunStatus',
-    'VisualRegressionTrackerError', 'ServerError', 'TestFailed',
+    'VisualRegressionTrackerError', 'ServerError', 'TestRunError',
     'VisualRegressionTracker',
 ]

--- a/visual_regression_tracker/__init__.py
+++ b/visual_regression_tracker/__init__.py
@@ -20,9 +20,11 @@ Basic usage:
 """
 
 from .types import Config, Build, TestRun, TestRunResult, TestRunStatus
+from .exceptions import VisualRegressionTrackerError, ServerError, TestFailed
 from .visualRegressionTracker import VisualRegressionTracker
 
 __all__ = [
     'Config', 'Build', 'TestRun', 'TestRunResult', 'TestRunStatus',
+    'VisualRegressionTrackerError', 'ServerError', 'TestFailed',
     'VisualRegressionTracker',
 ]

--- a/visual_regression_tracker/exceptions.py
+++ b/visual_regression_tracker/exceptions.py
@@ -2,26 +2,26 @@ from .types import TestRunStatus
 
 
 class VisualRegressionTrackerError(Exception):
-
     """An error occurred."""
+
     pass
 
 
 class ServerError(VisualRegressionTrackerError):
-
     """An error occurred on the VisualRegressionTracker server."""
 
     def __init__(self, response: dict, *args):
         """Initialises ServerError from server response."""
+
         self.response = response
         super(ServerError, self).__init__(*args)
 
 
 class TestRunError(VisualRegressionTrackerError):
-
     """A visual test failed."""
 
     def __init__(self, status: TestRunStatus, *args):
         """Initialises TestRunError error."""
+
         self.status = status
         super(TestRunError, self).__init__(*args)

--- a/visual_regression_tracker/exceptions.py
+++ b/visual_regression_tracker/exceptions.py
@@ -2,22 +2,24 @@ from .types import TestRunStatus
 
 
 class VisualRegressionTrackerError(Exception):
+
     """An error occurred."""
     pass
 
 
 class ServerError(VisualRegressionTrackerError):
+
     """An error occurred on the VisualRegressionTracker server."""
     def __init__(self, response: dict, *args):
-        """
-        Initialises ServerError from server response
-        """
+        """Initialises ServerError from server response."""
         self.response = response
         super(ServerError, self).__init__(*args)
 
 
 class TestFailed(VisualRegressionTrackerError):
+
     """A visual test failed."""
     def __init__(self, status: TestRunStatus, *args):
+        """Initialises TestFailed error."""
         self.status = status
         super(TestFailed, self).__init__(*args)

--- a/visual_regression_tracker/exceptions.py
+++ b/visual_regression_tracker/exceptions.py
@@ -2,11 +2,13 @@ from .types import TestRunStatus
 
 
 class VisualRegressionTrackerError(Exception):
+
     """An error occurred."""
     pass
 
 
 class ServerError(VisualRegressionTrackerError):
+
     """An error occurred on the VisualRegressionTracker server."""
 
     def __init__(self, response: dict, *args):
@@ -16,6 +18,7 @@ class ServerError(VisualRegressionTrackerError):
 
 
 class TestRunError(VisualRegressionTrackerError):
+
     """A visual test failed."""
 
     def __init__(self, status: TestRunStatus, *args):

--- a/visual_regression_tracker/exceptions.py
+++ b/visual_regression_tracker/exceptions.py
@@ -12,7 +12,6 @@ class ServerError(VisualRegressionTrackerError):
 
     def __init__(self, response: dict, *args):
         """Initialises ServerError from server response."""
-
         self.response = response
         super(ServerError, self).__init__(*args)
 
@@ -22,6 +21,5 @@ class TestRunError(VisualRegressionTrackerError):
 
     def __init__(self, status: TestRunStatus, *args):
         """Initialises TestRunError error."""
-
         self.status = status
         super(TestRunError, self).__init__(*args)

--- a/visual_regression_tracker/exceptions.py
+++ b/visual_regression_tracker/exceptions.py
@@ -19,6 +19,6 @@ class TestRunError(VisualRegressionTrackerError):
     """A visual test failed."""
 
     def __init__(self, status: TestRunStatus, *args):
-        """Initialises TestFailed error."""
+        """Initialises TestRunError error."""
         self.status = status
         super(TestRunError, self).__init__(*args)

--- a/visual_regression_tracker/exceptions.py
+++ b/visual_regression_tracker/exceptions.py
@@ -13,7 +13,7 @@ class ServerError(VisualRegressionTrackerError):
     def __init__(self, response: dict, *args):
         """Initialises ServerError from server response."""
         self.response = response
-        super(ServerError, self).__init__(*args)
+        super(ServerError, self).__init__(*args, response)
 
 
 class TestRunError(VisualRegressionTrackerError):
@@ -22,4 +22,4 @@ class TestRunError(VisualRegressionTrackerError):
     def __init__(self, status: TestRunStatus, *args):
         """Initialises TestRunError error."""
         self.status = status
-        super(TestRunError, self).__init__(*args)
+        super(TestRunError, self).__init__(*args, status)

--- a/visual_regression_tracker/exceptions.py
+++ b/visual_regression_tracker/exceptions.py
@@ -3,11 +3,11 @@ from .types import TestRunStatus
 
 class VisualRegressionTrackerError(Exception):
     """An error occurred."""
-    
     pass
 
 
 class ServerError(VisualRegressionTrackerError):
+
     """An error occurred on the VisualRegressionTracker server."""
 
     def __init__(self, response: dict, *args):
@@ -17,6 +17,7 @@ class ServerError(VisualRegressionTrackerError):
 
 
 class TestFailed(VisualRegressionTrackerError):
+
     """A visual test failed."""
 
     def __init__(self, status: TestRunStatus, *args):

--- a/visual_regression_tracker/exceptions.py
+++ b/visual_regression_tracker/exceptions.py
@@ -2,14 +2,14 @@ from .types import TestRunStatus
 
 
 class VisualRegressionTrackerError(Exception):
-
     """An error occurred."""
+    
     pass
 
 
 class ServerError(VisualRegressionTrackerError):
-
     """An error occurred on the VisualRegressionTracker server."""
+
     def __init__(self, response: dict, *args):
         """Initialises ServerError from server response."""
         self.response = response
@@ -17,8 +17,8 @@ class ServerError(VisualRegressionTrackerError):
 
 
 class TestFailed(VisualRegressionTrackerError):
-
     """A visual test failed."""
+
     def __init__(self, status: TestRunStatus, *args):
         """Initialises TestFailed error."""
         self.status = status

--- a/visual_regression_tracker/exceptions.py
+++ b/visual_regression_tracker/exceptions.py
@@ -1,0 +1,23 @@
+from .types import TestRunStatus
+
+
+class VisualRegressionTrackerError(Exception):
+    """An error occurred."""
+    pass
+
+
+class ServerError(VisualRegressionTrackerError):
+    """An error occurred on the VisualRegressionTracker server."""
+    def __init__(self, response: dict, *args):
+        """
+        Initialises ServerError from server response
+        """
+        self.response = response
+        super(ServerError, self).__init__(*args)
+
+
+class TestFailed(VisualRegressionTrackerError):
+    """A visual test failed."""
+    def __init__(self, status: TestRunStatus, *args):
+        self.status = status
+        super(TestFailed, self).__init__(*args)

--- a/visual_regression_tracker/exceptions.py
+++ b/visual_regression_tracker/exceptions.py
@@ -10,10 +10,9 @@ class VisualRegressionTrackerError(Exception):
 class ServerError(VisualRegressionTrackerError):
     """An error occurred on the VisualRegressionTracker server."""
 
-    def __init__(self, response: dict, *args):
+    def __init__(self, *args):
         """Initialises ServerError from server response."""
-        self.response = response
-        super(ServerError, self).__init__(*args, response)
+        super(ServerError, self).__init__(*args)
 
 
 class TestRunError(VisualRegressionTrackerError):

--- a/visual_regression_tracker/exceptions.py
+++ b/visual_regression_tracker/exceptions.py
@@ -2,24 +2,23 @@ from .types import TestRunStatus
 
 
 class VisualRegressionTrackerError(Exception):
-
     """An error occurred."""
     pass
 
 
 class ServerError(VisualRegressionTrackerError):
-
     """An error occurred on the VisualRegressionTracker server."""
+
     def __init__(self, response: dict, *args):
         """Initialises ServerError from server response."""
         self.response = response
         super(ServerError, self).__init__(*args)
 
 
-class TestFailed(VisualRegressionTrackerError):
-
+class TestRunError(VisualRegressionTrackerError):
     """A visual test failed."""
+
     def __init__(self, status: TestRunStatus, *args):
         """Initialises TestFailed error."""
         self.status = status
-        super(TestFailed, self).__init__(*args)
+        super(TestRunError, self).__init__(*args)

--- a/visual_regression_tracker/visualRegressionTracker.py
+++ b/visual_regression_tracker/visualRegressionTracker.py
@@ -104,6 +104,7 @@ def _http_request(url: str, method: str, data: dict, headers: dict) -> dict:
     request = getattr(requests, method.lower())
     response = request(url, json=data, headers=headers)
     status = response.status_code
+    result = response.json()
 
     if status == 401:
         raise Exception('Unauthorized')
@@ -111,7 +112,7 @@ def _http_request(url: str, method: str, data: dict, headers: dict) -> dict:
         raise Exception('Api key not authenticated')
     if status == 404:
         raise Exception('Project not found')
+    if status >= 400:
+        raise Exception(result)
 
-    response.raise_for_status()
-    result = response.json()
     return result

--- a/visual_regression_tracker/visualRegressionTracker.py
+++ b/visual_regression_tracker/visualRegressionTracker.py
@@ -6,7 +6,7 @@ from .types import \
     Config, Build, TestRun, TestRunResult, TestRunStatus, \
     _to_dict, _from_dict
 from .exceptions import \
-    ServerError, TestFailed, VisualRegressionTrackerError
+    ServerError, TestRunError, VisualRegressionTrackerError
 
 
 class VisualRegressionTracker:
@@ -99,7 +99,7 @@ class VisualRegressionTracker:
             if self.config.enableSoftAssert:
                 logging.getLogger(__name__).error(error_message)
             else:
-                raise TestFailed(result.status, error_message)
+                raise TestRunError(result.status, error_message)
 
 
 def _http_request(url: str, method: str, data: dict, headers: dict) -> dict:

--- a/visual_regression_tracker/visualRegressionTracker.py
+++ b/visual_regression_tracker/visualRegressionTracker.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import requests
@@ -109,12 +110,12 @@ def _http_request(url: str, method: str, data: dict, headers: dict) -> dict:
     result = response.json()
 
     if status == 401:
-        raise ServerError({}, 'Unauthorized')
+        raise ServerError('Unauthorized')
     if status == 403:
-        raise ServerError({}, 'Api key not authenticated')
+        raise ServerError('Api key not authenticated')
     if status == 404:
-        raise ServerError({}, 'Project not found')
+        raise ServerError('Project not found')
     if status >= 400:
-        raise ServerError(result, result.get('message', 'An error occurred'))
+        raise ServerError(json.dumps(result, indent=2))
 
     return result

--- a/visual_regression_tracker/visualRegressionTracker.py
+++ b/visual_regression_tracker/visualRegressionTracker.py
@@ -5,6 +5,8 @@ import requests
 from .types import \
     Config, Build, TestRun, TestRunResult, TestRunStatus, \
     _to_dict, _from_dict
+from .exceptions import \
+    ServerError, TestFailed, VisualRegressionTrackerError
 
 
 class VisualRegressionTracker:
@@ -42,7 +44,7 @@ class VisualRegressionTracker:
 
     def stop(self):
         if not self._isStarted():
-            raise Exception("Visual Regression Tracker has not been started")
+            raise VisualRegressionTrackerError("Visual Regression Tracker has not been started")
 
         _http_request(
             f'{self.config.apiUrl}/builds/{self.buildId}',
@@ -64,7 +66,7 @@ class VisualRegressionTracker:
 
     def _submitTestResult(self, test: TestRun) -> TestRunResult:
         if not self._isStarted():
-            raise Exception("Visual Regression Tracker has not been started")
+            raise VisualRegressionTrackerError("Visual Regression Tracker has not been started")
 
         data = _to_dict(test)
         data.update(
@@ -97,7 +99,7 @@ class VisualRegressionTracker:
             if self.config.enableSoftAssert:
                 logging.getLogger(__name__).error(error_message)
             else:
-                raise Exception(error_message)
+                raise TestFailed(result.status, error_message)
 
 
 def _http_request(url: str, method: str, data: dict, headers: dict) -> dict:
@@ -107,12 +109,12 @@ def _http_request(url: str, method: str, data: dict, headers: dict) -> dict:
     result = response.json()
 
     if status == 401:
-        raise Exception('Unauthorized')
+        raise ServerError({}, 'Unauthorized')
     if status == 403:
-        raise Exception('Api key not authenticated')
+        raise ServerError({}, 'Api key not authenticated')
     if status == 404:
-        raise Exception('Project not found')
+        raise ServerError({}, 'Project not found')
     if status >= 400:
-        raise Exception(result)
+        raise ServerError(result, result.get('message', 'An error occurred'))
 
     return result


### PR DESCRIPTION
In added trace info to server side exceptions and provide this info in response 
would like to see it's thrown instead of default http error

https://github.com/Visual-Regression-Tracker/Visual-Regression-Tracker/issues/128

before
```
requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: http://localhost:4200/test-runs
```

after
```
Exception: {'path': '/test-runs', 'name': 'PayloadTooLargeError', 'message': 'request entity too large', 'exception': {'message': 'request entity too large', 'expected': 441231, 'length': 441231, 'limit': 104857, 'type': 'entity.too.large'}, 'stack': 'PayloadTooLargeError: request entity too large\n    at readStream (/Users/pashidlos/work/vrt/backend/node_modules/raw-body/index.js:155:17)\n    at getRawBody (/Users/pashidlos/work/vrt/backend/node_modules/raw-body/index.js:108:12)\n    at read (/Users/pashidlos/work/vrt/backend/node_modules/body-parser/lib/read.js:77:3)\n    at jsonParser (/Users/pashidlos/work/vrt/backend/node_modules/body-parser/lib/types/json.js:135:5)\n    at Layer.handle [as handle_request] (/Users/pashidlos/work/vrt/backend/node_modules/express/lib/router/layer.js:95:5)\n    at trim_prefix (/Users/pashidlos/work/vrt/backend/node_modules/express/lib/router/index.js:317:13)\n    at /Users/pashidlos/work/vrt/backend/node_modules/express/lib/router/index.js:284:7\n    at Function.process_params (/Users/pashidlos/work/vrt/backend/node_modules/express/lib/router/index.js:335:12)\n    at next (/Users/pashidlos/work/vrt/backend/node_modules/express/lib/router/index.js:275:10)\n    at expressInit (/Users/pashidlos/work/vrt/backend/node_modules/express/lib/middleware/init.js:40:5)'}

```