### PR TITLE
Use urllib.parse.urljoin instead of string concat

### DIFF
--- a/visual_regression_tracker/visualRegressionTracker.py
+++ b/visual_regression_tracker/visualRegressionTracker.py
@@ -3,6 +3,8 @@ import logging
 
 import requests
 
+from urllib.parse import urljoin
+
 from .types import \
     Build, TestRun, TestRunResponse, TestRunStatus, \
     _to_dict, _from_dict, TestRunResult
@@ -37,7 +39,7 @@ class VisualRegressionTracker:
             'project': self.config.project,
         }
         result = _http_request(
-            f'{self.config.apiUrl}/builds',
+            urljoin(self.config.apiUrl,'/builds'),
             'post',
             data,
             self.headers


### PR DESCRIPTION
Fixes #25 

This is a quick fix, but I don't know if it breaks anything else, and to be honest I don't have time to check it right now. Hope it helps anyway.