### PR TITLE
Obtain TestRunResult at tracking with playwright

### DIFF
--- a/visual_regression_tracker/playwright.py
+++ b/visual_regression_tracker/playwright.py
@@ -66,7 +66,7 @@ class PlaywrightMixin:
         screenshot = page.screenshot(**screenshotOptions)
         imageBase64 = base64.b64encode(screenshot).decode('ascii')
 
-        self.track(TestRun(
+        return self.track(TestRun(
             name,
             imageBase64,
             options.agent.os if options and options.agent else None,
@@ -89,7 +89,7 @@ class PlaywrightMixin:
         screenshot = await page.screenshot(**screenshotOptions)
         imageBase64 = base64.b64encode(screenshot).decode('ascii')
 
-        self.track(TestRun(
+        return self.track(TestRun(
             name,
             imageBase64,
             options.agent.os if options and options.agent else None,
@@ -110,7 +110,7 @@ class PlaywrightMixin:
         screenshot = elementHandle.screenshot(**screenshotOptions)
         imageBase64 = base64.b64encode(screenshot).decode('ascii')
 
-        self.track(TestRun(
+        return self.track(TestRun(
             name,
             imageBase64,
             options.agent.os if options and options.agent else None,
@@ -131,7 +131,7 @@ class PlaywrightMixin:
         screenshot = await elementHandle.screenshot(**screenshotOptions)
         imageBase64 = base64.b64encode(screenshot).decode('ascii')
 
-        self.track(TestRun(
+        return self.track(TestRun(
             name,
             imageBase64,
             options.agent.os if options and options.agent else None,


### PR DESCRIPTION
Hi! Currently, It is not possible to obtain links to expected/actual/diff screenshots if you're using` PlaywrightVisualRegressionTracker` class. Playwright methods `trackPage*` don't return anything menawhile TestRunResult is expected.  
The changes just add `return` to the `trackPage*` methods in the class.