### PR TITLE
Expand TestRunStatus enum: added autoApproved

### DIFF
--- a/visual_regression_tracker/types.py
+++ b/visual_regression_tracker/types.py
@@ -34,6 +34,7 @@ class TestRunStatus(enum.Enum):
     NEW = 'new'
     OK = 'ok'
     UNRESOLVED = 'unresolved'
+    AUTO_APPROVED = 'autoApproved'
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
There is an exception when receiving autoApproved result from VRT as there is no such item in enum. Expanding enum to fix the problem
> ValueError: 'autoApproved' is not a valid TestRunStatus

```
/usr/local/lib/python3.10/site-packages/visual_regression_tracker/visualRegressionTracker.py:99: in track
    result = self._submitTestResult(test)
/usr/local/lib/python3.10/site-packages/visual_regression_tracker/visualRegressionTracker.py:93: in _submitTestResult
    result['status'] = TestRunStatus(result['status'])
/usr/local/lib/python3.10/enum.py:385: in __call__
    return cls.__new__(cls, value)
```